### PR TITLE
Skip caching empty progress response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kano/api-client",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "intercept calls between the server and the client try to minimise them",
   "main": "api-client.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kano/api-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "intercept calls between the server and the client try to minimise them",
   "main": "api-client.js",
   "directories": {

--- a/plugins/offline-gamification.js
+++ b/plugins/offline-gamification.js
@@ -94,7 +94,13 @@ export class OfflineGamificationPlugin {
             case 'trigger':
                 progress = {};
 
-                Object.keys(data).forEach((name) => {
+                const ruleNamesChanged = Object.keys(data);
+
+                if (ruleNamesChanged.length <= 0) {
+                    return Promise.resolve(data);
+                }
+
+                ruleNamesChanged.forEach((name) => {
                     progress[name] = data[name].progress;
                 });
 


### PR DESCRIPTION
This can happen when someone completes a previously completed challenge.