### PR TITLE
Fix the CORS issue on the /ping endpoint

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -43,6 +43,9 @@ export class Client {
     getEndpointResponseType(type = 'json') {
         return type;
     }
+    getEndpointMode(mode = 'cors') {
+        return mode;
+    }
     getEndpoint(name, ...args) {
         const endpointFunc = this.endpoints[name];
         if (!endpointFunc) {
@@ -57,6 +60,7 @@ export class Client {
                 method: this.getEndpointMethod(),
                 headers: this.getEndpointHeaders(),
                 responseType: this.getEndpointResponseType(),
+                mode: this.getEndpointMode(),
             };
         }
         const url = this.getEndpointUrl(endpoint.path, ...args);
@@ -71,6 +75,7 @@ export class Client {
             response: endpoint.response,
             responseType: this.getEndpointResponseType(endpoint.responseType),
             params: endpoint.params,
+            mode: this.getEndpointMode(endpoint.mode),
         };
     }
     fetch(endpoint) {
@@ -93,6 +98,7 @@ export class Client {
                 method: e.method,
                 headers: e.headers,
                 body: e.body,
+                mode: e.mode,
             }).then((r) => {
                 if (!r.ok) {
                     throw r;

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -5,6 +5,7 @@ const PING_ENDPOINTS = {
         return {
             path: '/ping',
             responseType: 'text',
+            mode: 'no-cors',
         };
     },
 };
@@ -13,7 +14,13 @@ export class PingClient extends Client {
     constructor(opts = {}) {
         super(opts);
         this.addEndpoints(PING_ENDPOINTS);
+
+        /* The /ping endpoint doesn't work with JSON. Remove these
+           to avoid hitting a CORS issue in the browser */
+        delete this.options.defaultHeaders.Accept;
+        delete this.options.defaultHeaders['Content-Type'];
     }
+
     ping() {
         const endpoint = this.getEndpoint('ping');
         return this.fetch(endpoint)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kano/api-client",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Intercept calls between the server and the client try to minimise them",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
No more  `Access to fetch at 'https://worldapi-dev.kano.me/ping' from origin 'http://localhost:4000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.`