### PR TITLE
Remove content-length header from avatar image uploads

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -249,7 +249,6 @@ export class UserClient extends Client {
                     body: image,
                     headers: {
                         'Content-Type': 'image/png',
-                        'Content-Length': image.size.toString(),
                     },
                 });
                 const promises = avatarUrls.map((url) => {


### PR DESCRIPTION
Causes an error in Chrome - the `Content-Length` header is ignored for security reasons